### PR TITLE
fetchData allow custom filter params.

### DIFF
--- a/stream_table.js
+++ b/stream_table.js
@@ -300,7 +300,12 @@
   };
 
   _F.fetchData = function(){
-    var _self = this, params = {q: this.last_search_text}
+    var _self = this, 
+        params = this.opts.params || {};
+    
+    if (!params['q']) {
+      params['q'] = this.last_search_text;
+    }
 
     if (this.opts.fetch_data_limit) {
       params['limit'] = this.opts.fetch_data_limit;


### PR DESCRIPTION
Many other places where you need to load an table, some values can be added to the params of the table, so the BE can filter this data and reduce the number of data sent. also query param can be set as part of the options before the table loads and the be filters.
